### PR TITLE
Re-write OS version check to match libgl deprecation version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ fi
 
 message_print "Installing apt dependencies..."
 
-if dpkg --compare-versions "$OS_VERSION" "ge" "24.10"
+if [ "$(echo "$OS_VERSION 23.10" | awk '{if ($1 > $2) print 1; else print 0;}')" -eq 1 ];
 then
     ALL_DEPS=("${APT_DEPS[@]}" "${APT_DEPS_NEW[@]}")
 else


### PR DESCRIPTION
- libgl1-mesa-glx is obsolete from Ubuntu 23.10 and onwards.
- dpkg output 0 regardless of OS version, therefore, I used my own logic to ensure this installation works.

ref: https://askubuntu.com/questions/1517352/issues-installing-libgl1-mesa-glx